### PR TITLE
1.3.0

### DIFF
--- a/lib/main.jsx
+++ b/lib/main.jsx
@@ -1,6 +1,3 @@
-const GitHubApi = require("github");
-const config = require('../package.json');
-
 const {ComponentRegistry} = require('nylas-exports');
 const {
   ThreadUnsubscribeQuickActionButton,
@@ -8,80 +5,21 @@ const {
 } = require('./ui/unsubscribe-buttons');
 
 const pluginUpdater = require('./ui/plugin-updater');
-
-const fs = require('fs-extra');
-const stripJsonComments = require('strip-json-comments');
-let settingsFile;
-const defaultSettings = `${__dirname}/../unsubscribe-settings.defaults.json`;
-const userSettings = `${__dirname}/../unsubscribe-settings.json`;
-try {
-  // Use user defined settings file, else the defaults
-  settingsFile = fs.readFileSync(userSettings, 'utf8');
-} catch (e) {
-  console.log(`n1-unsubscribe: Copying default settings to ${userSettings}.`);
-  fs.copySync(defaultSettings, userSettings);
-  settingsFile = fs.readFileSync(userSettings, 'utf8');
-}
-const settingsJSON = stripJsonComments(settingsFile);
-const settings = JSON.parse(settingsJSON);
-
-process.env.N1_UNSUBSCRIBE_USE_BROWSER = settings.use_browser === true ||
-  settings.use_browser === 'true';
-process.env.N1_UNSUBSCRIBE_THREAD_HANDLING = settings.handle_threads;
-process.env.N1_UNSUBSCRIBE_CONFIRM_EMAIL = settings.confirm_for_email === true ||
-  settings.confirm_for_email === 'true';
-process.env.N1_UNSUBSCRIBE_CONFIRM_BROWSER = settings.confirm_for_browser === true ||
-  settings.confirm_for_browser === 'true';
-
-// Print settings file
-const browserText = (process.env.n1UnsubscribeUseBrowser === 'true' ? '' : '(Popup)');
-console.log(
-  `n1-unsubscribe settings:
-  - Use native browser for unsubscribing: ${process.env.N1_UNSUBSCRIBE_USE_BROWSER} ${browserText}
-  - Archive or trash after unsubscribing: ${process.env.N1_UNSUBSCRIBE_THREAD_HANDLING}
-  - Confirm before email unsubscribing: ${process.env.N1_UNSUBSCRIBE_CONFIRM_EMAIL}
-  - Confirm before browser unsubscribing: ${process.env.N1_UNSUBSCRIBE_CONFIRM_BROWSER}`
-);
+const settings = require('./settings');
+settings.configure();
 
 module.exports = {
   // Activate is called when the package is loaded. If your package previously
   // saved state using `serialize` it is provided.
   //
   activate: () => {
+    settings.checkForUpdate(pluginUpdater);
     // ComponentRegistry.register ThreadUnsubscribeBulkAction,
     //   role: 'thread:BulkAction'
     ComponentRegistry.register(ThreadUnsubscribeQuickActionButton,
       { role: 'ThreadListQuickAction' });
     ComponentRegistry.register(ThreadUnsubscribeToolbarButton,
       { role: 'ThreadActionsToolbarButton' });
-
-    const github = new GitHubApi({
-      version: '3.0.0',
-      debug: false,
-      protocol: 'https',
-      host: 'api.github.com',
-      timeout: 5000,
-      headers: {
-        'user-agent': 'N1-Updater',
-      },
-    });
-    github.releases.listReleases({
-      owner: 'colinking',
-      repo: 'n1-unsubscribe',
-      per_page: 1,
-    }, (err, res) => {
-      if (err) console.log(err);
-      const curVer = config.version;
-      if (res[0].tag_name !== curVer && res[0].draft === false) {
-        const relURL = res[0].html_url;
-        console.log(res[0]);
-        console.log(res[0].assets[0].download_url);
-        console.log(`New release available at ${relURL}!`);
-        console.log(this);
-        return pluginUpdater.activate('new', relURL, curVer);
-      }
-      return false;
-    });
   },
 
   // This **optional** method is called when the window is shutting down,

--- a/lib/main.jsx
+++ b/lib/main.jsx
@@ -4,9 +4,9 @@ const {
   ThreadUnsubscribeToolbarButton,
 } = require('./ui/unsubscribe-buttons');
 
-const pluginUpdater = require('./ui/plugin-updater');
 const settings = require('./settings');
 settings.configure();
+const pluginUpdater = require('./ui/plugin-updater');
 
 module.exports = {
   // Activate is called when the package is loaded. If your package previously
@@ -14,8 +14,9 @@ module.exports = {
   //
   activate: () => {
     settings.checkForUpdate(pluginUpdater);
-    // ComponentRegistry.register ThreadUnsubscribeBulkAction,
-    //   role: 'thread:BulkAction'
+    // ComponentRegistry.register(ThreadUnsubscribeBulkAction,
+    //   { role: 'ThreadListBulkAction' });
+    // //   role: 'thread:BulkAction'
     ComponentRegistry.register(ThreadUnsubscribeQuickActionButton,
       { role: 'ThreadListQuickAction' });
     ComponentRegistry.register(ThreadUnsubscribeToolbarButton,
@@ -29,6 +30,7 @@ module.exports = {
   //
   deactivate: () => {
     pluginUpdater.deactivate();
+    // ComponentRegistry.register(ThreadUnsubscribeBulkAction);
     ComponentRegistry.unregister(ThreadUnsubscribeQuickActionButton);
     ComponentRegistry.unregister(ThreadUnsubscribeToolbarButton);
   },

--- a/lib/persistent-settings/thanks-false.json
+++ b/lib/persistent-settings/thanks-false.json
@@ -1,0 +1,3 @@
+{
+	"displayThanksNotification": false
+}

--- a/lib/persistent-settings/thanks-true.json
+++ b/lib/persistent-settings/thanks-true.json
@@ -1,0 +1,3 @@
+{
+	"displayThanksNotification": true
+}

--- a/lib/persistent-settings/thanks.json
+++ b/lib/persistent-settings/thanks.json
@@ -1,0 +1,3 @@
+{
+	"displayThanksNotification": true
+}

--- a/lib/settings.jsx
+++ b/lib/settings.jsx
@@ -1,0 +1,86 @@
+// Configure()
+const fs = require('fs-extra');
+const stripJsonComments = require('strip-json-comments');
+// checkForUpdate()
+const GitHubApi = require("github");
+const config = require('../package.json');
+
+module.exports = {
+  // configure() needs to be called at the beginning of main.jsx
+  // Loads user settings or reverts to defaults
+  //
+  configure: () => {
+    const defaultSettings = `${__dirname}/../unsubscribe-settings.defaults.json`;
+    const userSettings = `${__dirname}/../unsubscribe-settings.json`;
+    let settingsFile;
+    try {
+      // Use user defined settings file, else the defaults
+      settingsFile = fs.readFileSync(userSettings, 'utf8');
+    } catch (e) {
+      console.log(`n1-unsubscribe: Copying default settings to ${userSettings}.`);
+      fs.copySync(defaultSettings, userSettings);
+      settingsFile = fs.readFileSync(userSettings, 'utf8');
+    }
+    const settingsJSON = stripJsonComments(settingsFile);
+    const settings = JSON.parse(settingsJSON);
+
+    // Configure global variables
+    process.env.N1_UNSUBSCRIBE_USE_BROWSER = settings.use_browser === true ||
+      settings.use_browser === 'true';
+    process.env.N1_UNSUBSCRIBE_THREAD_HANDLING = settings.handle_threads;
+    process.env.N1_UNSUBSCRIBE_CONFIRM_EMAIL = settings.confirm_for_email === true ||
+      settings.confirm_for_email === 'true';
+    process.env.N1_UNSUBSCRIBE_CONFIRM_BROWSER = settings.confirm_for_browser === true ||
+      settings.confirm_for_browser === 'true';
+
+    // Print settings file to console
+    const browserText = (process.env.n1UnsubscribeUseBrowser === 'true' ? '' : '(Popup)');
+    const useBrowser = process.env.N1_UNSUBSCRIBE_USE_BROWSER;
+    console.log(
+      `n1-unsubscribe settings:
+      - Use preferred browser for unsubscribing: ${useBrowser} ${browserText}
+      - Archive or trash after unsubscribing: ${process.env.N1_UNSUBSCRIBE_THREAD_HANDLING}
+      - Confirm before email unsubscribing: ${process.env.N1_UNSUBSCRIBE_CONFIRM_EMAIL}
+      - Confirm before browser unsubscribing: ${process.env.N1_UNSUBSCRIBE_CONFIRM_BROWSER}`
+    );
+  },
+  // checkForUpdate() sends a request to the Github API to see if a new release is available
+  // The function also updates global variables with package settings
+  //
+  checkForUpdate: (pluginUpdater) => {
+    const github = new GitHubApi({
+      version: '3.0.0',
+      debug: false,
+      protocol: 'https',
+      host: 'api.github.com',
+      timeout: 5000,
+      headers: {
+        'user-agent': 'N1-Updater',
+      },
+    });
+    github.releases.listReleases({
+      owner: 'colinking',
+      repo: 'n1-unsubscribe',
+      per_page: 1,
+    }, (err, res) => {
+      if (err) console.log(err);
+      const curVer = config.version;
+      const avaVer = res[0].name;
+      // res[0].name -> "1.2.3"
+      // res[0].tag_name -> "1.2.3"
+      if (avaVer !== curVer && res[0].draft === false) {
+        // Update globals:
+        process.env.N1_UNSUBSCRIBE_CURRENT_VER = curVer;
+        process.env.N1_UNSUBSCRIBE_AVAILABLE_VER = avaVer;
+        const releaseURL = res[0].html_url;
+        process.env.N1_UNSUBSCRIBE_AVAILABLE_URL = releaseURL;
+        console.log(`New release available at ${releaseURL}!`);
+        const downloadURL = res[0].assets[0].browser_download_url;
+        process.env.N1_UNSUBSCRIBE_DOWNLOAD_URL = downloadURL;
+        // Fire notification event
+        return pluginUpdater.activate('NEW_RELEASE');
+      }
+      return false;
+    });
+  },
+}

--- a/lib/thread-unsubscribe-store.es6
+++ b/lib/thread-unsubscribe-store.es6
@@ -1,5 +1,3 @@
-const currentVersion = "1.2.2";
-
 const {
   Actions,
   TaskFactory,
@@ -13,33 +11,6 @@ const BrowserWindow = require('electron').remote.BrowserWindow;
 const MailParser = require('mailparser').MailParser;
 const ThreadConditionType = require(`${__dirname}/enum/threadConditionType`);
 const open = require('open');
-
-// Get the latest release to check if an update is needed
-const GitHubApi = require("github");
-const github = new GitHubApi({
-  version: "3.0.0",
-  debug: false,
-  protocol: "https",
-  host: "api.github.com",
-  timeout: 5000,
-  headers: {
-    "user-agent": "N1-Updater",
-  },
-});
-github.releases.listReleases({
-  owner: "colinking",
-  repo: "n1-unsubscribe",
-  per_page: 1,
-}, (err, res) => {
-  if (err) console.log(err);
-  // Get latest release:
-  // console.log(res[0]);
-  if (res[0].tag_name !== currentVersion &&
-    res[0].draft === false) {
-    console.log('New release!');
-    console.log(res[0].assets[0].browser_download_url);
-  }
-});
 
 class ThreadUnsubscribeStore extends NylasStore {
   constructor(thread) {

--- a/lib/ui/plugin-updater.cjsx
+++ b/lib/ui/plugin-updater.cjsx
@@ -5,38 +5,10 @@ module.exports =
 
   activate: (@state) ->
     @_unlisten = Actions.notificationActionTaken.listen(@_onNotificationActionTaken, @)
-    return @displayNotification(process.env.N1_UNSUBSCRIBE_AVAILABLE_VER)
-
-    # configVersion = NylasEnv.config.get("lastVersion")
-    # currentVersion = NylasEnv.getVersion()
-    # if configVersion and configVersion isnt currentVersion
-    #   NylasEnv.config.set("lastVersion", currentVersion)
-    #   @displayThanksNotification()
-
-    # if updater.getState() is 'update-available'
-    #   @displayNotification(updater.releaseVersion)
-
-    # NylasEnv.onUpdateAvailable ({releaseVersion, releaseNotes} = {}) =>
-    #   @displayNotification(releaseVersion)
-
-  displayThanksNotification: ->
-    Actions.postNotification
-      type: 'info'
-      tag: 'app-update'
-      sticky: true
-      message: "You're running the latest version of N1-Unsubscribe (Plugin)" +
-        " - view the changelog to see what's new.",
-      icon: 'fa-magic'
-      actions: [{
-        dismisses: true
-        label: 'Thanks'
-        id: 'release-bar:no-op'
-      },{
-        default: true
-        dismisses: true
-        label: 'See What\'s New'
-        id: 'release-bar:view-plugin-changelog'
-      }]
+    if (@state is 'NEW_RELEASE')
+      return @displayNotification(process.env.N1_UNSUBSCRIBE_AVAILABLE_VER)
+    else if (@state is 'THANKS')
+      return @displayThanksNotification()
 
   displayNotification: (version) ->
     version = if version then "(#{version})" else ''
@@ -55,6 +27,25 @@ module.exports =
         dismisses: true
         default: true
         id: 'release-bar:install-plugin-update'
+      }]
+
+  displayThanksNotification: ->
+    Actions.postNotification
+      type: 'info'
+      tag: 'app-update'
+      sticky: true
+      message: "You're running the latest version of N1-Unsubscribe (Plugin)" +
+        " - view the changelog to see what's new.",
+      icon: 'fa-magic'
+      actions: [{
+        label: 'Thanks'
+        dismisses: true
+        id: 'release-bar:no-op'
+      },{
+        label: 'See What\'s New'
+        # dismisses: true
+        default: true
+        id: 'release-bar:view-plugin-changelog'
       }]
 
   deactivate: ->

--- a/lib/ui/plugin-updater.cjsx
+++ b/lib/ui/plugin-updater.cjsx
@@ -1,0 +1,101 @@
+# Get the latest release to check if an update is needed
+GitHubApi = require("github");
+config = require('../../package.json');
+
+{Actions} = require 'nylas-exports'
+{ipcRenderer, remote} = require('electron')
+
+module.exports =
+
+  # activate: (@state) ->
+  activate: (@state, relURL, curVer) ->
+    # console.log 'THIS STATE:'
+    # console.log @
+    # console.log @state
+    # console.log @state.state
+    @_unlisten = Actions.notificationActionTaken.listen(@_onNotificationActionTaken, @)
+    return @displayNotification(curVer)
+
+    # configVersion = NylasEnv.config.get("lastVersion")
+    # currentVersion = NylasEnv.getVersion()
+    # if configVersion and configVersion isnt currentVersion
+    #   NylasEnv.config.set("lastVersion", currentVersion)
+    #   @displayThanksNotification()
+    # github = new GitHubApi(
+    #   version: '3.0.0'
+    #   debug: false
+    #   protocol: 'https'
+    #   host: 'api.github.com'
+    #   timeout: 5000
+    #   headers: 'user-agent': 'N1-Updater'
+    # )
+    # github.releases.listReleases {
+    #   owner: 'colinking'
+    #   repo: 'n1-unsubscribe'
+    #   per_page: 1
+    # }, (err, res) ->
+    #   if err
+    #     console.log err
+    #   # Get latest release:
+    #   console.log res[0]
+    #   curVer = config.version
+    #   if res[0].tag_name isnt curVer and res[0].draft is false
+    #     relURL = res[0].html_url
+    #     # console.log(res[0].assets[0].browser_download_url);
+    #     console.log "New release available at #{relURL}!"
+    #     console.log @
+    #     return @displayNotification(curVer)
+    #   false
+
+    # if updater.getState() is 'update-available'
+    #   @displayNotification(updater.releaseVersion)
+
+    # NylasEnv.onUpdateAvailable ({releaseVersion, releaseNotes} = {}) =>
+    #   @displayNotification(releaseVersion)
+
+  displayThanksNotification: ->
+    Actions.postNotification
+      type: 'info'
+      tag: 'app-update'
+      sticky: true
+      message: "You're running the latest version of N1 - view the changelog to see what's new.",
+      icon: 'fa-magic'
+      actions: [{
+        dismisses: true
+        label: 'Thanks'
+        id: 'release-bar:no-op'
+      },{
+        default: true
+        dismisses: true
+        label: 'See What\'s New'
+        id: 'release-bar:view-plugin-changelog'
+      }]
+
+  displayNotification: (version) ->
+    version = if version then "(#{version})" else ''
+    Actions.postNotification
+      type: 'info'
+      tag: 'app-update'
+      sticky: true
+      message: "An update to N1-Unsubscribe is available #{version} - click to update now!",
+      icon: 'fa-flag'
+      actions: [{
+        label: 'See What\'s New'
+        id: 'release-bar:view-plugin-changelog'
+      },{
+        label: 'Install Now'
+        dismisses: true
+        default: true
+        id: 'release-bar:install-plugin-update'
+      }]
+
+  deactivate: ->
+    @_unlisten()
+
+  _onNotificationActionTaken: ({notification, action}) ->
+    if action.id is 'release-bar:install-plugin-update'
+      require('electron').shell.openExternal('https://github.com/colinking/n1-unsubscribe/releases/latest')
+      true
+    if action.id is 'release-bar:view-plugin-changelog'
+      require('electron').shell.openExternal('https://github.com/colinking/n1-unsubscribe/releases/latest')
+      false

--- a/lib/ui/plugin-updater.cjsx
+++ b/lib/ui/plugin-updater.cjsx
@@ -1,51 +1,17 @@
-# Get the latest release to check if an update is needed
-GitHubApi = require("github");
-config = require('../../package.json');
-
 {Actions} = require 'nylas-exports'
 {ipcRenderer, remote} = require('electron')
 
 module.exports =
 
-  # activate: (@state) ->
-  activate: (@state, relURL, curVer) ->
-    # console.log 'THIS STATE:'
-    # console.log @
-    # console.log @state
-    # console.log @state.state
+  activate: (@state) ->
     @_unlisten = Actions.notificationActionTaken.listen(@_onNotificationActionTaken, @)
-    return @displayNotification(curVer)
+    return @displayNotification(process.env.N1_UNSUBSCRIBE_AVAILABLE_VER)
 
     # configVersion = NylasEnv.config.get("lastVersion")
     # currentVersion = NylasEnv.getVersion()
     # if configVersion and configVersion isnt currentVersion
     #   NylasEnv.config.set("lastVersion", currentVersion)
     #   @displayThanksNotification()
-    # github = new GitHubApi(
-    #   version: '3.0.0'
-    #   debug: false
-    #   protocol: 'https'
-    #   host: 'api.github.com'
-    #   timeout: 5000
-    #   headers: 'user-agent': 'N1-Updater'
-    # )
-    # github.releases.listReleases {
-    #   owner: 'colinking'
-    #   repo: 'n1-unsubscribe'
-    #   per_page: 1
-    # }, (err, res) ->
-    #   if err
-    #     console.log err
-    #   # Get latest release:
-    #   console.log res[0]
-    #   curVer = config.version
-    #   if res[0].tag_name isnt curVer and res[0].draft is false
-    #     relURL = res[0].html_url
-    #     # console.log(res[0].assets[0].browser_download_url);
-    #     console.log "New release available at #{relURL}!"
-    #     console.log @
-    #     return @displayNotification(curVer)
-    #   false
 
     # if updater.getState() is 'update-available'
     #   @displayNotification(updater.releaseVersion)
@@ -58,7 +24,8 @@ module.exports =
       type: 'info'
       tag: 'app-update'
       sticky: true
-      message: "You're running the latest version of N1 - view the changelog to see what's new.",
+      message: "You're running the latest version of N1-Unsubscribe (Plugin)" +
+        " - view the changelog to see what's new.",
       icon: 'fa-magic'
       actions: [{
         dismisses: true
@@ -77,7 +44,8 @@ module.exports =
       type: 'info'
       tag: 'app-update'
       sticky: true
-      message: "An update to N1-Unsubscribe is available #{version} - click to update now!",
+      message: "An update to N1-Unsubscribe (Plugin) is available" +
+        " #{process.env.N1_UNSUBSCRIBE_AVAILABLE_VER} - click to update now!",
       icon: 'fa-flag'
       actions: [{
         label: 'See What\'s New'
@@ -93,9 +61,9 @@ module.exports =
     @_unlisten()
 
   _onNotificationActionTaken: ({notification, action}) ->
-    if action.id is 'release-bar:install-plugin-update'
-      require('electron').shell.openExternal('https://github.com/colinking/n1-unsubscribe/releases/latest')
-      true
     if action.id is 'release-bar:view-plugin-changelog'
-      require('electron').shell.openExternal('https://github.com/colinking/n1-unsubscribe/releases/latest')
+      require('electron').shell.openExternal(process.env.N1_UNSUBSCRIBE_AVAILABLE_URL)
       false
+    if action.id is 'release-bar:install-plugin-update'
+      require('electron').shell.openExternal(process.env.N1_UNSUBSCRIBE_DOWNLOAD_URL)
+      true

--- a/lib/ui/plugin-updater.cjsx
+++ b/lib/ui/plugin-updater.cjsx
@@ -11,9 +11,10 @@ module.exports =
       return @displayThanksNotification()
 
   displayNotification: (version) ->
+    # Types: `info`, `developer`, `error`, or `success`
     version = if version then "(#{version})" else ''
     Actions.postNotification
-      type: 'info'
+      type: 'developer'
       tag: 'app-update'
       sticky: true
       message: "An update to N1-Unsubscribe (Plugin) is available" +
@@ -31,7 +32,7 @@ module.exports =
 
   displayThanksNotification: ->
     Actions.postNotification
-      type: 'info'
+      type: 'developer'
       tag: 'app-update'
       sticky: true
       message: "You're running the latest version of N1-Unsubscribe (Plugin)" +

--- a/stylesheets/main.less
+++ b/stylesheets/main.less
@@ -43,3 +43,12 @@
 		background: url(@unsubscribe-success-img) center no-repeat;
 	}
 }
+
+
+// Color the actions.postNotification bar to differentiate between a plugin update vs. N1 update
+// Currently tweaked to minimally interfere by using one `info`, `developer`, `error`, or `success` types
+// developer seemed to be the least likely to interfere with regular users
+// But it would be great to have a new type for this use
+.notifications-sticky .notification-developer {
+	background-color: #60CBF1 !important;
+}


### PR DESCRIPTION
- Created a working notification on new Github release found
- Finally understood module.export and OOP, so cleaned up main.jsx by moving the settings configuration code into its own file, settings.json and used global variables (process.env) to make the notification more robust
- Hacked together a persistent data store working within the Nylas-allowed permissions to fire a thank you notification when updated
- Colored the thank you/install notification to differentiate from N1 update
